### PR TITLE
Fixes #8: Sending signals on IPNs

### DIFF
--- a/paypaladaptive/api/ipn/signals.py
+++ b/paypaladaptive/api/ipn/signals.py
@@ -1,0 +1,9 @@
+import django.dispatch
+
+
+preapproval_approved = django.dispatch.Signal()
+preapproval_canceled = django.dispatch.Signal()
+preapproval_error = django.dispatch.Signal()
+
+payment_completed = django.dispatch.Signal()
+payment_error = django.dispatch.Signal()


### PR DESCRIPTION
There are now 5 different signals being sent, depending on the content of the IPN:
preapproval_approved
preapproval_canceled
preapproval_error
payment_completed
payment_error
